### PR TITLE
Enclose CSV entries in double quotes if needed

### DIFF
--- a/openmole/plugins/org.openmole.plugin.hook.file/src/main/scala/org/openmole/plugin/hook/file/AppendToCSVFileHook.scala
+++ b/openmole/plugins/org.openmole.plugin.hook.file/src/main/scala/org/openmole/plugin/hook/file/AppendToCSVFileHook.scala
@@ -80,8 +80,15 @@ abstract class AppendToCSVFileHook(
             )
           }
 
-        def writeLine[T](list: List[T]) =
-          fos.appendLine(list.map(l ⇒ l.prettify()).mkString(","))
+        def writeLine[T](list: List[T]) = {
+          fos.appendLine(list.map(l ⇒ {
+            val prettified = l.prettify()
+            if (prettified.contains(',') || prettified.contains('"')) {
+              '"' + prettified.replaceAll("\"", "\"\"") + '"'
+            }
+            else prettified
+          }).mkString(","))
+        }
 
         write(lists)
     }


### PR DESCRIPTION
See issue #18.

This pull request only changes the writing of prettified strings to the CSV file. If such string contains a comma or a double quote, the entire string is enclose in double quotes after replacing all double quotes within the string by two double quotes. This is compatible with Excel and other CSV libraries (see [SO](http://stackoverflow.com/questions/10451842/how-to-escape-comma-and-double-quote-at-same-time-for-csv-file))