### PR TITLE
enh: Add singleRow option to AppendToCSVFileHook

### DIFF
--- a/openmole/plugins/org.openmole.plugin.hook.file/src/main/scala/org/openmole/plugin/hook/file/AppendToCSVFileHook.scala
+++ b/openmole/plugins/org.openmole.plugin.hook.file/src/main/scala/org/openmole/plugin/hook/file/AppendToCSVFileHook.scala
@@ -39,6 +39,7 @@ object AppendToCSVFileHook {
 abstract class AppendToCSVFileHook(
     fileName: ExpandedString,
     header: Option[ExpandedString],
+    singleRow: Boolean,
     prototypes: Prototype[_]*) extends Hook {
 
   override def process(context: Context, executionContext: ExecutionContext) = {
@@ -71,13 +72,17 @@ abstract class AppendToCSVFileHook(
 
         def moreThanOneElement(l: List[_]) = !l.isEmpty && !l.tail.isEmpty
 
+        def flatAny(o: Any): List[Any] = o match {
+          case o: List[_] ⇒ o
+          case _          ⇒ List(o)
+        }
+
         @tailrec def write(lists: List[List[_]]): Unit =
-          if (!lists.exists(moreThanOneElement)) writeLine(lists.map { _.head })
+          if (singleRow || !lists.exists(moreThanOneElement))
+            writeLine(lists.flatten(flatAny))
           else {
             writeLine(lists.map { _.head })
-            write(
-              lists.map { l ⇒ if (moreThanOneElement(l)) l.tail else l }
-            )
+            write(lists.map { l ⇒ if (moreThanOneElement(l)) l.tail else l })
           }
 
         def writeLine[T](list: List[T]) = {

--- a/openmole/plugins/org.openmole.plugin.hook.file/src/main/scala/org/openmole/plugin/hook/file/AppendToCSVFileHookBuilder.scala
+++ b/openmole/plugins/org.openmole.plugin.hook.file/src/main/scala/org/openmole/plugin/hook/file/AppendToCSVFileHookBuilder.scala
@@ -25,11 +25,17 @@ import org.openmole.core.workflow.tools.ExpandedString
 class AppendToCSVFileHookBuilder(fileName: ExpandedString, prototypes: Prototype[_]*) extends HookBuilder {
   prototypes.foreach(p ⇒ addInput(p))
   private var csvHeader: Option[ExpandedString] = None
+  private var singleRow: Boolean = false
 
   def setCSVHeader(h: Option[ExpandedString]) = {
     csvHeader = h
     this
   }
 
-  override def toHook = new AppendToCSVFileHook(fileName, csvHeader, prototypes: _*) with Built
+  def setSingleRow(b: Boolean) = {
+    singleRow = b
+    this
+  }
+
+  override def toHook = new AppendToCSVFileHook(fileName, csvHeader, singleRow, prototypes: _*) with Built
 }

--- a/openmole/plugins/org.openmole.plugin.hook.file/src/main/scala/org/openmole/plugin/hook/file/package.scala
+++ b/openmole/plugins/org.openmole.plugin.hook.file/src/main/scala/org/openmole/plugin/hook/file/package.scala
@@ -32,4 +32,5 @@ package object file {
 
   def csvHeader = set[{ def setCSVHeader(h: Option[ExpandedString]) }]
 
+  def singleRow = set[{ def setSingleRow(b: Boolean) }]
 }


### PR DESCRIPTION
The singleRow option can be used to force the flattening of the input lists such that all variables values are written to a single row/line of the CSV file.

See issue #18.