### PR TITLE
Capture log message from sshj (fix #49)

### DIFF
--- a/libraries/project/src/main/scala/OSGi.scala
+++ b/libraries/project/src/main/scala/OSGi.scala
@@ -43,7 +43,7 @@ object OSGi extends Defaults(Apache) {
     version := "3.2.9"
     )*/
 
-  lazy val logback = OsgiProject("ch.qos.logback", exports = Seq("ch.qos.logback.*", "org.slf4j.impl")) settings
+  lazy val logback = OsgiProject("ch.qos.logback", exports = Seq("ch.qos.logback.*", "org.slf4j.impl"), dynamicImports = Seq("*")) settings
     (libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.0.9", version := "1.0.9")
 
   lazy val h2Version = "1.3.176"

--- a/openmole/bin/openmole/src/main/resources/configuration/logback.xml
+++ b/openmole/bin/openmole/src/main/resources/configuration/logback.xml
@@ -15,7 +15,7 @@
 
     <appender name="CatchSSH" class="org.openmole.core.logging.OpenMOLEAppender">
         <encoder>
-            <pattern>(ssh) %date %level [%thread] %logger{10} [%file : %line] %msg%n</pattern>
+            <pattern>%date %level [%thread] %logger{10} [%file : %line] %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/openmole/bin/openmole/src/main/resources/configuration/logback.xml
+++ b/openmole/bin/openmole/src/main/resources/configuration/logback.xml
@@ -15,7 +15,7 @@
 
     <appender name="CatchSSH" class="org.openmole.core.logging.OpenMOLEAppender">
         <encoder>
-            <pattern>%date %level [%thread] %logger{10} [%file : %line] %msg%n</pattern>
+            <pattern>%date [%thread] %logger{10} [%file : %line] %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/openmole/bin/openmole/src/main/resources/configuration/logback.xml
+++ b/openmole/bin/openmole/src/main/resources/configuration/logback.xml
@@ -13,7 +13,17 @@
        <level value="ALL"/>
    </logger>
 
-   <root level="debug">
+    <appender name="CatchSSH" class="org.openmole.core.logging.OpenMOLEAppender">
+        <encoder>
+            <pattern>(ssh) %date %level [%thread] %logger{10} [%file : %line] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="net.schmizz.concurrent.Promise" additivity="false">
+        <appender-ref ref="CatchSSH" />
+    </logger>
+
+    <root level="debug">
        <appender-ref ref="STDOUT" />
    </root>
 </configuration>

--- a/openmole/bin/openmole/src/main/resources/openmole
+++ b/openmole/bin/openmole/src/main/resources/openmole
@@ -56,7 +56,7 @@ done
 mkdir -p "$HOME/.openmole/.tmp/"
 CONFIGDIR=$HOME/.openmole/.tmp/`date +%s`_$RANDOM
 
-java -Dfile.encoding=UTF-8 -Djava.security.egd=file:/dev/./urandom -Dosgi.locking=none -Dopenmole.location="${LOCATION}" -Dosgi.classloader.singleThreadLoads=true  -Dosgi.configuration.area="${CONFIGDIR}" -Xmx${MEM} $FLAG -XX:+UseG1GC \
+java -Dlogback.configurationFile=${LOCATION}/configuration/logback.xml -Dfile.encoding=UTF-8 -Djava.security.egd=file:/dev/./urandom -Dosgi.locking=none -Dopenmole.location="${LOCATION}" -Dosgi.classloader.singleThreadLoads=true  -Dosgi.configuration.area="${CONFIGDIR}" -Xmx${MEM} $FLAG -XX:+UseG1GC \
      -jar "$LOCATION/plugins/org.eclipse.equinox.launcher.jar" -consoleLog \
      -cp "$LOCATION/openmole-plugins" -gp "$LOCATION/openmole-plugins-gui" "${ARGS[@]}"
 

--- a/openmole/bin/openmole/src/main/resources/openmole.bat
+++ b/openmole/bin/openmole/src/main/resources/openmole.bat
@@ -9,7 +9,7 @@ java -d64 -version >nul 2>&1
 if errorlevel 1 goto is32bit
 set FLAG="-XX:+UseCompressedOops"
 :is32bit
-java -Dfile.encoding=UTF-8 -Dosgi.locking=none -Dopenmole.location="%PWD%\" -Dosgi.classloader.singleThreadLoads=true -Dosgi.configuration.area=%ran% -XX:MaxPermSize=128M -XX:+UseG1GC -Xmx1G  -XX:MaxPermSize=128M %FLAG% -jar "%PWD%/plugins/org.eclipse.equinox.launcher.jar" -consoleLog -cp "%PWD%/openmole-plugins" -gp "%PWD%/openmole-plugins-gui" %*
+java -Dlogback.configurationFile="%PWD%/configuration/logback.xml -Dfile.encoding=UTF-8 -Dosgi.locking=none -Dopenmole.location="%PWD%\" -Dosgi.classloader.singleThreadLoads=true -Dosgi.configuration.area=%ran% -XX:MaxPermSize=128M -XX:+UseG1GC -Xmx1G  -XX:MaxPermSize=128M %FLAG% -jar "%PWD%/plugins/org.eclipse.equinox.launcher.jar" -consoleLog -cp "%PWD%/openmole-plugins" -gp "%PWD%/openmole-plugins-gui" %*
 set ret=%errorlevel%
 rmdir /s /q %ran%
 EXIT /B %ret%

--- a/openmole/core/org.openmole.core.logging/src/main/scala/org/openmole/core/logging/OpenMOLEAppender.scala
+++ b/openmole/core/org.openmole.core.logging/src/main/scala/org/openmole/core/logging/OpenMOLEAppender.scala
@@ -51,8 +51,7 @@ class OpenMOLEAppender extends AppenderBase[ILoggingEvent] with Logger {
       try {
         encoder.doEncode(event)
         Log.logger.fine(byteOutputStream.toString)
-        // FIXME ??? needed ???
-        //        byteOutputStream.reset
+        byteOutputStream.reset
       }
       catch {
         case e: IOException ⇒

--- a/openmole/core/org.openmole.core.logging/src/main/scala/org/openmole/core/logging/OpenMOLEAppender.scala
+++ b/openmole/core/org.openmole.core.logging/src/main/scala/org/openmole/core/logging/OpenMOLEAppender.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 Jonathan Passerat-Palmbach
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.openmole.core.logging
+
+import java.io.{ ByteArrayOutputStream, IOException }
+
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import org.openmole.core.tools.service.Logger
+
+class OpenMOLEAppender extends AppenderBase[ILoggingEvent] with Logger {
+
+  import OpenMOLEAppender._
+
+  def setLimit(inLimit: Int) = limit = inLimit
+
+  def getLimit = limit
+
+  override def start {
+    if (encoder != null) {
+      try {
+        encoder.init(byteOutputStream)
+      }
+      catch {
+        case e: IOException ⇒
+      }
+      super.start
+    }
+    else addError("No encoder set for the appender named [" + name + "].")
+  }
+
+  def append(event: ILoggingEvent) {
+    if (counter < limit) {
+      // output the events as formatted by our layout
+      try {
+        encoder.doEncode(event)
+        Log.logger.fine(byteOutputStream.toString)
+        // FIXME ??? needed ???
+        //        byteOutputStream.reset
+      }
+      catch {
+        case e: IOException ⇒
+      }
+
+      // prepare for next event
+      counter += 1
+    }
+  }
+
+  def getEncoder = encoder
+
+  def setEncoder(inEncoder: PatternLayoutEncoder) {
+    encoder = inEncoder
+  }
+}
+
+object OpenMOLEAppender {
+
+  val DEFAULT_LIMIT = 10
+
+  val byteOutputStream = new ByteArrayOutputStream
+
+  var counter = 0
+  var limit = DEFAULT_LIMIT
+  var encoder = new PatternLayoutEncoder
+}

--- a/openmole/core/org.openmole.core.logging/src/main/scala/org/openmole/core/logging/OpenMOLEAppender.scala
+++ b/openmole/core/org.openmole.core.logging/src/main/scala/org/openmole/core/logging/OpenMOLEAppender.scala
@@ -26,11 +26,8 @@ import org.openmole.core.tools.service.Logger
 
 class OpenMOLEAppender extends AppenderBase[ILoggingEvent] with Logger {
 
-  import OpenMOLEAppender._
-
-  def setLimit(inLimit: Int) = limit = inLimit
-
-  def getLimit = limit
+  val byteOutputStream = new ByteArrayOutputStream
+  var encoder = new PatternLayoutEncoder
 
   override def start {
     if (encoder != null) {
@@ -46,36 +43,18 @@ class OpenMOLEAppender extends AppenderBase[ILoggingEvent] with Logger {
   }
 
   def append(event: ILoggingEvent) {
-    if (counter < limit) {
-      // output the events as formatted by our layout
-      try {
-        encoder.doEncode(event)
-        Log.logger.fine(byteOutputStream.toString)
-        byteOutputStream.reset
-      }
-      catch {
-        case e: IOException ⇒
-      }
-
-      // prepare for next event
-      counter += 1
+    try {
+      encoder.doEncode(event)
+      Log.logger.fine(byteOutputStream.toString)
+      byteOutputStream.reset
+    }
+    catch {
+      case e: IOException ⇒
     }
   }
 
   def getEncoder = encoder
-
   def setEncoder(inEncoder: PatternLayoutEncoder) {
     encoder = inEncoder
   }
-}
-
-object OpenMOLEAppender {
-
-  val DEFAULT_LIMIT = 10
-
-  val byteOutputStream = new ByteArrayOutputStream
-
-  var counter = 0
-  var limit = DEFAULT_LIMIT
-  var encoder = new PatternLayoutEncoder
 }

--- a/openmole/project/src/main/scala/root/Core.scala
+++ b/openmole/project/src/main/scala/root/Core.scala
@@ -61,7 +61,7 @@ object Core extends Defaults {
 
   val logging = OsgiProject(
     "logging",
-    bundleActivator = Some("org.openmole.core.logging.internal.Activator"), imports = Seq("*")) settings (libraryDependencies ++= Seq(log4j, logback, slf4j, equinoxCommon)) dependsOn
+    bundleActivator = Some("org.openmole.core.logging.internal.Activator"), imports = Seq("*"), dynamicImports = Seq("*")) settings (libraryDependencies ++= Seq(log4j, logback, slf4j, equinoxCommon)) dependsOn
     (tools, workspace)
 
   val output = OsgiProject("output", imports = Seq("*"))

--- a/openmole/project/src/main/scala/root/Core.scala
+++ b/openmole/project/src/main/scala/root/Core.scala
@@ -61,7 +61,7 @@ object Core extends Defaults {
 
   val logging = OsgiProject(
     "logging",
-    bundleActivator = Some("org.openmole.core.logging.internal.Activator"), imports = Seq("*"), dynamicImports = Seq("*")) settings (libraryDependencies ++= Seq(log4j, logback, slf4j, equinoxCommon)) dependsOn
+    bundleActivator = Some("org.openmole.core.logging.internal.Activator"), imports = Seq("*")) settings (libraryDependencies ++= Seq(log4j, logback, slf4j, equinoxCommon)) dependsOn
     (tools, workspace)
 
   val output = OsgiProject("output", imports = Seq("*"))


### PR DESCRIPTION
Implement an `Appender` to `logback` and update `logback.xml` to deport log messages from *sshj* to OpenMOLE's `LoggerService`