### PR TITLE
Add && and || operators to workflow Condition trait

### DIFF
--- a/openmole/core/org.openmole.core.workflow/src/main/scala/org/openmole/core/workflow/transition/Condition.scala
+++ b/openmole/core/org.openmole.core.workflow/src/main/scala/org/openmole/core/workflow/transition/Condition.scala
@@ -58,4 +58,7 @@ trait Condition { c ⇒
     override def evaluate(context: Context)(implicit rng: RandomProvider): Boolean = !c.evaluate(context)
   }
 
+  def &&(d: Condition) = new Condition {
+    override def evaluate(context: Context)(implicit rng: RandomProvider): Boolean = c.evaluate(context) && d.evaluate(context)
+  }
 }

--- a/openmole/core/org.openmole.core.workflow/src/main/scala/org/openmole/core/workflow/transition/Condition.scala
+++ b/openmole/core/org.openmole.core.workflow/src/main/scala/org/openmole/core/workflow/transition/Condition.scala
@@ -61,4 +61,8 @@ trait Condition { c ⇒
   def &&(d: Condition) = new Condition {
     override def evaluate(context: Context)(implicit rng: RandomProvider): Boolean = c.evaluate(context) && d.evaluate(context)
   }
+
+  def ||(d: Condition) = new Condition {
+    override def evaluate(context: Context)(implicit rng: RandomProvider): Boolean = c.evaluate(context) || d.evaluate(context)
+  }
 }


### PR DESCRIPTION
These operators should allow all needed combination of conditions used within the Skip or Switch cases. They are yet untested (though the modification is straightforward). Will apply the && in my workflow plugin soon.