### PR TITLE
[Plugin] enh: Use ExpandedString for CSV file path argument in CSVSampling

### DIFF
--- a/openmole/plugins/org.openmole.plugin.sampling.csv/src/main/scala/org/openmole/plugin/sampling/csv/CSVSampling.scala
+++ b/openmole/plugins/org.openmole.plugin.sampling.csv/src/main/scala/org/openmole/plugin/sampling/csv/CSVSampling.scala
@@ -30,6 +30,7 @@ import java.math.BigInteger
 import java.math.BigDecimal
 import org.openmole.core.workflow.data._
 import org.openmole.core.workflow.sampling._
+import org.openmole.core.workflow.tools.ExpandedString
 import au.com.bytecode.opencsv.CSVReader
 import collection.JavaConversions._
 import scala.collection.mutable.ListBuffer
@@ -37,10 +38,10 @@ import scala.util.Random
 
 object CSVSampling {
 
-  def apply(file: File) = new CSVSamplingBuilder(file)
+  def apply(file: ExpandedString) = new CSVSamplingBuilder(file)
 }
 
-abstract class CSVSampling(val file: File) extends Sampling with CSVToVariables {
+abstract class CSVSampling(val file: ExpandedString) extends Sampling with CSVToVariables {
 
   override def prototypes =
     columns.map { case (_, p) ⇒ p } :::

--- a/openmole/plugins/org.openmole.plugin.sampling.csv/src/main/scala/org/openmole/plugin/sampling/csv/CSVSamplingBuilder.scala
+++ b/openmole/plugins/org.openmole.plugin.sampling.csv/src/main/scala/org/openmole/plugin/sampling/csv/CSVSamplingBuilder.scala
@@ -21,10 +21,11 @@ import java.io.File
 
 import org.openmole.core.workflow.builder.SamplingBuilder
 import org.openmole.core.workflow.data.Prototype
+import org.openmole.core.workflow.tools.ExpandedString
 
 import scala.collection.mutable.ListBuffer
 
-class CSVSamplingBuilder(file: File) extends SamplingBuilder { builder ⇒
+class CSVSamplingBuilder(file: ExpandedString) extends SamplingBuilder { builder ⇒
   private var _columns = new ListBuffer[(String, Prototype[_])]
   private var _fileColumns = new ListBuffer[(String, File, Prototype[File])]
   private var separator: Option[Char] = Some(',')

--- a/openmole/plugins/org.openmole.plugin.tool.csv/src/main/scala/org/openmole/plugin/tool/csv/CSVToVariables.scala
+++ b/openmole/plugins/org.openmole.plugin.tool.csv/src/main/scala/org/openmole/plugin/tool/csv/CSVToVariables.scala
@@ -24,6 +24,7 @@ import au.com.bytecode.opencsv.CSVReader
 import org.openmole.core.exception.UserBadDataError
 import org.openmole.core.workflow.data._
 import org.openmole.core.workflow.sampling._
+import org.openmole.core.workflow.tools.ExpandedString
 
 import scala.util.Random
 
@@ -37,8 +38,8 @@ trait CSVToVariables {
    * Builds the plan.
    *
    */
-  def toVariables(file: File, context: Context): Iterator[Iterable[Variable[_]]] = {
-    val reader = new CSVReader(new FileReader(file), separator)
+  def toVariables(file: ExpandedString, context: Context)(implicit rng: RandomProvider): Iterator[Iterable[Variable[_]]] = {
+    val reader = new CSVReader(new FileReader(file.from(context)), separator)
     val headers = reader.readNext.toArray
 
     //test wether prototype names belong to header names


### PR DESCRIPTION
Some other plugins which inject (content) of a file into the workflow such as SelectFileDomain or FileSource already use an ExpandedString as file path argument instead of a plain "File" or "Path". By also changing the argument type of the CSVSampling to ExpandedString, it is possible to explore a CSV file who's path depends on some input variables of the ExplorationTask.