### PR TITLE
Fix uDocker symlinks

### DIFF
--- a/openmole/plugins/org.openmole.plugin.task.udocker/src/main/scala/org/openmole/plugin/task/udocker/UDocker.scala
+++ b/openmole/plugins/org.openmole.plugin.task.udocker/src/main/scala/org/openmole/plugin/task/udocker/UDocker.scala
@@ -105,7 +105,11 @@ object UDocker {
       // lock before existence tests to account for incomplete files
       layersDirectory.withLockInDirectory {
         if (!layerFileInLayers.exists()) layer._2 move layerFileInLayers
-        if (!layerFileInRepos.exists()) layerFileInRepos createLinkTo layerFileInLayers.getAbsolutePath
+        if (!layerFileInRepos.exists()) {
+          // clean potential broken link before recreating a valid one
+          if (layerFileInRepos.isBrokenSymbolicLink) layerFileInRepos.delete()
+          layerFileInRepos createLinkTo layerFileInLayers.getAbsolutePath
+        }
       }
     }
 

--- a/openmole/third-parties/org.openmole.tool.file/src/main/scala/org/openmole/tool/file/package.scala
+++ b/openmole/third-parties/org.openmole.tool.file/src/main/scala/org/openmole/tool/file/package.scala
@@ -182,6 +182,8 @@ package file {
 
       def isSymbolicLink = Files.isSymbolicLink(Paths.get(file.getAbsolutePath))
 
+      def isBrokenSymbolicLink = Files.notExists(Files.readSymbolicLink(file))
+
       def directoryContainsNoFileRecursive: Boolean = {
         val toProceed = new ListBuffer[File]
         toProceed += file

--- a/openmole/third-parties/org.openmole.tool.file/src/test/scala/org/openmole/tool/file/FileUtilSpec.scala
+++ b/openmole/third-parties/org.openmole.tool.file/src/test/scala/org/openmole/tool/file/FileUtilSpec.scala
@@ -17,7 +17,7 @@
 
 package org.openmole.tool.file
 
-import java.nio.file.Files
+import java.nio.file.{ Files, Paths }
 
 import org.openmole.tool.file._
 import org.openmole.tool.stream._
@@ -26,17 +26,17 @@ import org.scalatest._
 
 class FileUtilSpec extends FlatSpec with Matchers {
 
-  "A string" should "be append to the stream" in {
+  "A string" should "be appended to the stream" in {
     val t = "TestString"
     val sis = new StringOutputStream
     try {
       sis.append(t)
       sis.toString should equal(t)
     }
-    finally sis.close
+    finally sis.close()
   }
 
-  "A string" should "be append to the file" in {
+  "A string" should "be appended to the file" in {
     val file = Files.createTempFile("test", ".tmp").toFile
     try {
       val t1 = "TestString"
@@ -46,6 +46,33 @@ class FileUtilSpec extends FlatSpec with Matchers {
       file.content should equal(t1 + t2)
     }
     finally file.delete
+  }
+
+  "A broken symbolic link" should "be reported as such" in {
+    val brokenPath = Paths.get("/tmp/gibberish")
+    val link = Paths.get("/tmp/linktarget").toFile
+    link createLinkTo brokenPath
+    try {
+      link.isSymbolicLink should equal(true)
+      link.isBrokenSymbolicLink should equal(true)
+    }
+    finally {
+      link.delete()
+    }
+  }
+
+  "A valid symbolic link" should "be reported as such" in {
+    val file = Files.createTempFile("test", ".tmp").toFile
+    val link = Paths.get("/tmp/linktarget").toFile
+    link createLinkTo file
+    try {
+      link.isSymbolicLink should equal(true)
+      link.isBrokenSymbolicLink should equal(false)
+    }
+    finally {
+      link.delete()
+      file.delete()
+    }
   }
 
 }


### PR DESCRIPTION
When a broken symlink was present in the local persistent repo, new executions involving the same imaging were failing with:

```
org.openmole.core.exception.InternalProcessingError: Error for context values in org.openmole.core.workflow.tools.InputOutputCheck$@5416865f {arg=1, openmole$seed=-5582255697660668453}
	at org.openmole.core.workflow.tools.InputOutputCheck$.$anonfun$perform$1(InputOutputCheck.scala:91)
	at org.openmole.core.expansion.FromContext$$anon$9.from(FromContext.scala:162)
	...
Caused by: java.nio.file.FileAlreadyExistsException: /home/jopasserat/.openmole/astaroth/persistent/udocker/repos/biomedia/abdominal_stitching/latest/sha256:386a066cd84a33a04d560c42bef66d1dd64ebfc76de78550e5fd0f8d57778bca
	...
	at java.nio.file.Files.createSymbolicLink(Files.java:1043)
	at org.openmole.tool.file.FilePackage$FileDecorator.createLinkTo(package.scala:348)
	at org.openmole.tool.file.FilePackage$FileDecorator.createLinkTo(package.scala:338)
	at org.openmole.plugin.task.udocker.UDocker$.$anonfun$buildRepoV2$2(UDocker.scala:108)
	at org.openmole.tool.file.FilePackage$FileDecorator.$anonfun$withLockInDirectory$1(package.scala:374)
	at org.openmole.tool.file.FilePackage$FileDecorator.$anonfun$withLock$5(package.scala:365)
	at org.openmole.tool.stream.package$.withClosable(package.scala:117)
	at org.openmole.tool.file.FilePackage$FileDecorator.$anonfun$withLock$3(package.scala:363)
	at org.openmole.tool.stream.package$.withClosable(package.scala:117)
	at org.openmole.tool.file.FilePackage$FileDecorator.$anonfun$withLock$1(package.scala:362)
	at org.openmole.tool.lock.LockRepository.withLock(LockRepository.scala:54)
	at org.openmole.tool.file.FilePackage$FileDecorator.withLock(package.scala:362)
	at org.openmole.tool.file.FilePackage$FileDecorator.withLockInDirectory(package.scala:374)
	at org.openmole.plugin.task.udocker.UDocker$.$anonfun$buildRepoV2$1(UDocker.scala:106)
	...
	at org.openmole.plugin.task.udocker.UDocker$.buildRepoV2(UDocker.scala:100)
	at org.openmole.plugin.task.udocker.UDockerTask.$anonfun$process$1(UDockerTask.scala:236)
	at org.openmole.core.expansion.FromContext$$anon$8.from(FromContext.scala:156)
	at org.openmole.core.workflow.tools.InputOutputCheck$.$anonfun$perform$1(InputOutputCheck.scala:88)
	... 18 more
```