### PR TITLE
fix netlogo file inputs by adding quotes

### DIFF
--- a/openmole/plugins/org.openmole.plugin.task.netlogo/src/main/scala/org/openmole/plugin/task/netlogo/NetLogoTask.scala
+++ b/openmole/plugins/org.openmole.plugin.task.netlogo/src/main/scala/org/openmole/plugin/task/netlogo/NetLogoTask.scala
@@ -92,7 +92,7 @@ trait NetLogoTask extends Task with ValidateTask {
           for (inBinding ← netLogoInputs) {
             val v = preparedContext(inBinding._1) match {
               case x: String ⇒ '"' + x + '"'
-              case x: File   ⇒ '"' + x.toString + '"'
+              case x: File   ⇒ '"' + x.getAbsolutePath + '"'
               case x         ⇒ x.toString
             }
             executeNetLogo("set " + inBinding._2 + " " + v)

--- a/openmole/plugins/org.openmole.plugin.task.netlogo/src/main/scala/org/openmole/plugin/task/netlogo/NetLogoTask.scala
+++ b/openmole/plugins/org.openmole.plugin.task.netlogo/src/main/scala/org/openmole/plugin/task/netlogo/NetLogoTask.scala
@@ -92,6 +92,7 @@ trait NetLogoTask extends Task with ValidateTask {
           for (inBinding ← netLogoInputs) {
             val v = preparedContext(inBinding._1) match {
               case x: String ⇒ '"' + x + '"'
+              case x: File   ⇒ '"' + x.toString + '"'
               case x         ⇒ x.toString
             }
             executeNetLogo("set " + inBinding._2 + " " + v)


### PR DESCRIPTION
Adds a specific case for the conversion of Openmole types to netlogo ones. 

The values of type files should be quoted. 

Fix https://github.com/openmole/openmole/issues/278
