### PR TITLE
fix the path of the built binary in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,5 @@ git lfs fetch
 (cd libraries && sbt publishLocal)
 (cd openmole && sbt "project openmole" assemble)
 
-(echo openmole is ready in openmole/bin/openmole/assemble/)
+(echo openmole is ready in openmole/bin/openmole/target/assemble/)
 


### PR DESCRIPTION
Cosmetic fix

when the build.sh script ends, it displays where we can find the assembled openmole 

this path was not in line with the website doc nor reality 
