### PR TITLE
Creation of workDirectory

### DIFF
--- a/openmole/plugins/org.openmole.plugin.environment.ssh/src/main/scala/org/openmole/plugin/environment/ssh/SharedStorage.scala
+++ b/openmole/plugins/org.openmole.plugin.environment.ssh/src/main/scala/org/openmole/plugin/environment/ssh/SharedStorage.scala
@@ -112,7 +112,11 @@ object SharedStorage extends JavaLogger {
         script.content = content
 
         val remoteScript = sharedFS.child(serializedJob.path, uniqName("run", ".sh"))
-        UsageControl.withToken(sharedFS.usageControl) { sharedFS.upload(script, remoteScript, options = TransferOptions(raw = true, forceCopy = true, canMove = true))(_) }
+        UsageControl.withToken(sharedFS.usageControl) { token ⇒
+
+          sharedFS.makeDir(baseWorkDirectory)(token)
+          sharedFS.upload(script, remoteScript, options = TransferOptions(raw = true, forceCopy = true, canMove = true))(token)
+        }
         remoteScript
       }
     (remoteScript, result, baseWorkDirectory)


### PR DESCRIPTION
Attempt at ensuring `workDirectory` is created before the jobs are submitted.
(needed by some batch schedulers in order to populate stdout and err).

To no success so far..