### PR TITLE
minor typo fix in Model Import Wizard panel

### DIFF
--- a/openmole/gui/client/org.openmole.gui.client.core/src/main/scala/org/openmole/gui/client/core/ModelWizardPanel.scala
+++ b/openmole/gui/client/org.openmole.gui.client.core/src/main/scala/org/openmole/gui/client/core/ModelWizardPanel.scala
@@ -362,10 +362,10 @@ class ModelWizardPanel {
   )
 
   val step2 = div(
-    div(grey)("The systems detects automatically the launching command and propose you the creation of some OpenMOLE Variables so that" +
-      " your model will be able to be feeded with variable values coming from the workflow you will build afterwards. In the case of Java, Scala, Netlogo" +
-      "(ie codes working on the JVM) the OpenMOLE variables can be set directly in the command line. Otherwise, they have to be set inside ${} statements." +
-      " By default he systems detects automatically your Variable changes and update the launching command. However, this option can be desactivated.")
+    div(grey)("The system detects automatically the launching command and propose you the creation of some OpenMOLE variables so that" +
+      " your model will be able to be feeded with variable values coming from the workflow you will build afterwards. In the case of Java, Scala or Netlogo" +
+      " (ie codes working on the JVM), the OpenMOLE variables can be set directly in the command line. Otherwise, they have to be set inside ${} statements." +
+      " By default the system detects automatically your variable changes and update the launching command. However, this option can be desactivated.")
   )
 
   val autoModeTag = div(onecolumn +++ (paddingTop := 20))(


### PR DESCRIPTION
Minor typo correction. Mainly  to get started with openmole file system and documentations, I may add more commit I go through all the step to explore a simple model.