### PR TITLE
Add a line to remind to add a while loop

### DIFF
--- a/openmole/bin/org.openmole.site/jvm/src/main/scalatex/openmole/documentation/run/NetLogo.scalatex
+++ b/openmole/bin/org.openmole.site/jvm/src/main/scalatex/openmole/documentation/run/NetLogo.scalatex
@@ -27,6 +27,7 @@
       outputs += burned mapped "burned-trees"
     )"""
 
+
 @def csvHook = """
   val csvHook = AppendToCSVFileHook(workDirectory / "result.csv", density, burned, seed)"""
 
@@ -61,7 +62,11 @@ In this example, the command list contains:
   @ul
     @li{@code{random-seed} initializing the random number generator of NetLogo using the seed provided by OpenMOLE,}
     @li{@code{setup} calling the setup function of the nlogo file,}
-    @li{@code{go} running the model. For this particular model, this function is called until no more turtles are active.}
+    @li{@code{go} running the model. For this particular model, this function is called until no more turtles are active. }
+
+If you use the forever button @code{go} in the NetLogo GUI don't forget that you @i{will} need something like @code{"while [condition] [go]"} in the command list, as openmole won't loop your @code{go} function by default.
+
+@br
 
 The @code{replication} and @code{density} OpenMOLE variables are used as parameters of the NetLogo program.
 Therefore they appear as inputs of the NetLogoTask.


### PR DESCRIPTION
 When using the forever option in Netlogo GUI for the GO button, it should be added a while in the command list.
```scala
  val cmds = List(
    "random-seed ${seed}",
    "setup",
    "while [any? turtles] [go]")
```

I'm just thinking about this, but can't the wizard check that? and add a more explicit comment like "hey dude, sounds like you were using a forever button, you may need a while loop here!" 