### PR TITLE
Update PluginDevelopment.scalatex

### DIFF
--- a/openmole/bin/org.openmole.site/jvm/src/main/scalatex/openmole/documentation/developers/PluginDevelopment.scalatex
+++ b/openmole/bin/org.openmole.site/jvm/src/main/scalatex/openmole/documentation/developers/PluginDevelopment.scalatex
@@ -51,7 +51,7 @@ OsgiKeys.exportPackage := Seq("myopenmoleplugin.*")
 
 OsgiKeys.importPackage := Seq("*;resolution:=optional")
 
-OsgiKeys.privatePackage := Seq("*")
+OsgiKeys.privatePackage := Seq("!scala.*","*")
 
 OsgiKeys.requireCapability := ${tq}osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"${tq}
 """)


### PR DESCRIPTION
Change in the osgi bundle instructions, specifically in OsgiKeys.privatePackage to avoid embedding the scala standard lib in the bundle. This is to avoid compilation errors in scala projects or projects depending on scala libs. Does not matter for a pure java project.